### PR TITLE
Refine API handlers

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1,1 +1,11 @@
-export default function handler(req, res){res.setHeader("content-type","application/json");res.setHeader("access-control-allow-origin","*");res.status(200).end(JSON.stringify({ok:true, env:!!process.env.OPEN_CLOUD_KEY}))}
+export default function handler(req, res) {
+  res.setHeader("content-type", "application/json");
+  res.setHeader("access-control-allow-origin", "*");
+  res.status(200);
+  res.end(
+    JSON.stringify({
+      ok: true,
+      env: Boolean(process.env.OPEN_CLOUD_KEY),
+    })
+  );
+}


### PR DESCRIPTION
## Summary
- format the health check endpoint and keep the response headers consistent
- harden promote handler JSON parsing and numeric validation for Roblox IDs
- avoid sending empty JSON bodies for PATCH requests and surface timeout/network failures clearly

## Testing
- node --check api/promote.js
- node --check api/health.js

------
https://chatgpt.com/codex/tasks/task_b_68cd86a4b78c832dae83823d8af82776