### PR TITLE
Use Open Cloud PATCH payload for promotions

### DIFF
--- a/api/promote.js
+++ b/api/promote.js
@@ -65,8 +65,7 @@ export default async function handler(req, res) {
     };
 
     const attempts = [
-      { where: "cloudV2-PATCH", url: `https://apis.roblox.com/cloud/v2/groups/${groupId}/users/${userId}/roles/${roleId}`, method: "PATCH", payload: undefined },
-      { where: "cloudV2-POST",  url: `https://apis.roblox.com/cloud/v2/groups/${groupId}/users/${userId}/roles/${roleId}`, method: "POST",  payload: {} },
+      { where: "cloudV2-PATCH", url: `https://apis.roblox.com/cloud/v2/groups/${groupId}/users/${userId}`, method: "PATCH", payload: { roleId } },
       { where: "groupsV1-PATCH",url: `https://groups.roblox.com/v1/groups/${groupId}/users/${userId}`,                         method: "PATCH", payload: { roleId } },
       { where: "groupsV1-POST", url: `https://groups.roblox.com/v1/groups/${groupId}/users/${userId}`,                         method: "POST",  payload: { roleId } },
     ];


### PR DESCRIPTION
## Summary
- update the cloud v2 promotion attempt to use the PATCH endpoint without the role segment and send the roleId payload

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68cd83c9f29c832d9d576af9eeb84817