### PR TITLE
Fix Open Cloud promotion endpoint

### DIFF
--- a/api/promote.js
+++ b/api/promote.js
@@ -52,7 +52,7 @@ export default async function handler(req, res) {
         const resp = await fetch(url, {
           method,
           headers: { "x-api-key": key, "content-type": "application/json" },
-          body: payload ? JSON.stringify(payload) : "{}",
+          body: payload === undefined ? undefined : JSON.stringify(payload),
           signal: ctrl.signal
         });
         const text = await resp.text();
@@ -65,8 +65,7 @@ export default async function handler(req, res) {
     };
 
     const attempts = [
-      { where: "cloudV2-PATCH", url: `https://apis.roblox.com/cloud/v2/groups/${groupId}/users/${userId}/roles/${roleId}`, method: "PATCH", payload: undefined },
-      { where: "cloudV2-POST",  url: `https://apis.roblox.com/cloud/v2/groups/${groupId}/users/${userId}/roles/${roleId}`, method: "POST",  payload: {} },
+      { where: "cloudV2-PATCH", url: `https://apis.roblox.com/cloud/v2/groups/${groupId}/users/${userId}`,                    method: "PATCH", payload: { roleId } },
       { where: "groupsV1-PATCH",url: `https://groups.roblox.com/v1/groups/${groupId}/users/${userId}`,                         method: "PATCH", payload: { roleId } },
       { where: "groupsV1-POST", url: `https://groups.roblox.com/v1/groups/${groupId}/users/${userId}`,                         method: "POST",  payload: { roleId } },
     ];


### PR DESCRIPTION
## Summary
- update the Open Cloud promotion attempt to call the supported PATCH endpoint and send the required roleId JSON payload
- avoid sending an empty JSON body when a request does not need one

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cd814d58ac832da8e192217be92f23